### PR TITLE
Fix embind GameSession construction failure

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,25 +1,44 @@
 #include <cstdint>
 #include <emscripten/bind.h>
+#include <emscripten/val.h>
 
 #include "game.hpp"
 
+namespace {
+
+emscripten::val toJsArray(const std::vector<CellUpdate> &updates) {
+    emscripten::val array = emscripten::val::array();
+    for (std::size_t i = 0; i < updates.size(); ++i) {
+        const auto &update = updates[i];
+        emscripten::val item = emscripten::val::object();
+        item.set("x", update.x);
+        item.set("y", update.y);
+        item.set("revealed", update.revealed);
+        item.set("flagged", update.flagged);
+        item.set("mine", update.mine);
+        item.set("adjacent", update.adjacent);
+        item.set("detonated", update.detonated);
+        item.set("newlyDiscovered", update.newlyDiscovered);
+        array.set(i, item);
+    }
+    return array;
+}
+
+}  // namespace
+
 EMSCRIPTEN_BINDINGS(infinite_minesweeper) {
-    emscripten::value_object<CellUpdate>("CellUpdate")
-        .field("x", &CellUpdate::x)
-        .field("y", &CellUpdate::y)
-        .field("revealed", &CellUpdate::revealed)
-        .field("flagged", &CellUpdate::flagged)
-        .field("mine", &CellUpdate::mine)
-        .field("adjacent", &CellUpdate::adjacent)
-        .field("detonated", &CellUpdate::detonated)
-        .field("newlyDiscovered", &CellUpdate::newlyDiscovered);
-
-    emscripten::register_vector<CellUpdate>("CellUpdateVector");
-
     emscripten::class_<GameSession>("GameSession")
         .constructor<std::uint64_t>()
-        .function("reveal", &GameSession::reveal)
-        .function("toggleFlag", &GameSession::toggleFlag)
+        .function(
+            "reveal",
+            emscripten::optional_override([](GameSession &session, int x, int y) {
+                return toJsArray(session.reveal(x, y));
+            }))
+        .function(
+            "toggleFlag",
+            emscripten::optional_override([](GameSession &session, int x, int y) {
+                return toJsArray(session.toggleFlag(x, y));
+            }))
         .function("reset", &GameSession::reset)
         .function("setMineProbability", &GameSession::setMineProbability)
         .function("mineProbability", &GameSession::mineProbability)

--- a/web/app.js
+++ b/web/app.js
@@ -91,19 +91,26 @@ function applyUpdates(updates) {
   render();
 }
 
-function vecToArray(vector) {
-  const result = [];
-  const size = vector.size();
-  for (let i = 0; i < size; i += 1) {
-    result.push(vector.get(i));
+function normalizeUpdates(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value.size === "function") {
+    const result = [];
+    const size = value.size();
+    for (let i = 0; i < size; i += 1) {
+      result.push(value.get(i));
+    }
+    if (typeof value.delete === "function") {
+      value.delete();
+    }
+    return result;
   }
-  vector.delete();
-  return result;
+  return [];
 }
 
 function revealCell(x, y) {
   if (!game || !alive) return;
-  const updates = vecToArray(game.reveal(x, y));
+  const updates = normalizeUpdates(game.reveal(x, y));
   applyUpdates(updates);
   alive = game.isAlive();
   if (!alive) {
@@ -113,7 +120,7 @@ function revealCell(x, y) {
 
 function toggleFlag(x, y) {
   if (!game) return;
-  const updates = vecToArray(game.toggleFlag(x, y));
+  const updates = normalizeUpdates(game.toggleFlag(x, y));
   applyUpdates(updates);
 }
 


### PR DESCRIPTION
## Summary
- convert the embind layer to emit plain JavaScript objects for update results so GameSession can be constructed without unbound type errors
- update the web client to consume either native arrays or legacy embind vectors when processing game updates

## Testing
- make build *(fails: em++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d41afe86ec832e97c74eb953703921