### PR TITLE
Implement block locking and hints for infinite minesweeper

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,8 @@
       </p>
       <p class="hud__status" id="status"></p>
     </div>
+    <div class="target-indicator" id="target-indicator" aria-live="polite"></div>
+    <div class="action-warning" id="action-warning" aria-live="assertive"></div>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/web/main.js
+++ b/web/main.js
@@ -2,6 +2,7 @@ import * as PIXI from "https://cdn.jsdelivr.net/npm/pixi.js@7.3.3/dist/pixi.mjs"
 
 const CELL_SIZE = 48;
 const CHUNK_SIZE = 8;
+const BLOCK_SIZE = 30;
 const MIN_SCALE = 0.35;
 const MAX_SCALE = 2.8;
 const GROUPING_THRESHOLD = 0.65;
@@ -36,6 +37,12 @@ const styles = {
   empty: new PIXI.TextStyle({
     fill: "#f8fafc",
     fontSize: 20,
+    fontWeight: "600",
+    fontFamily: "Inter, 'Segoe UI', sans-serif",
+  }),
+  lock: new PIXI.TextStyle({
+    fill: "#facc15",
+    fontSize: 22,
     fontWeight: "600",
     fontFamily: "Inter, 'Segoe UI', sans-serif",
   }),
@@ -110,6 +117,20 @@ const hud = {
   status: document.getElementById("status"),
 };
 
+const overlays = {
+  targetIndicator: document.getElementById("target-indicator"),
+  actionWarning: document.getElementById("action-warning"),
+};
+
+const STORAGE_KEY = "infinite-minesweeper-save-v2";
+const SAVE_DEBOUNCE = 250;
+const START_REGION_SIZE = 30;
+
+const forcedSafeCells = new Set();
+let warningTimeoutId = null;
+let pendingSaveId = null;
+let lastSavedSnapshot = "";
+
 const state = {
   seed: randomSeedString(),
   seedValue: 1,
@@ -127,12 +148,16 @@ const state = {
   needsRender: true,
   revealedSafe: 0,
   exploded: false,
+  startRegionGenerated: false,
+  startRegionOrigin: null,
+  restoring: false,
 };
 
 const mineCache = new Map();
 const cellStates = new Map();
 const cellGraphics = new Map();
 const chunkGraphics = new Map();
+const blockStates = new Map();
 
 const CHUNK_WORLD_SIZE = CHUNK_SIZE * CELL_SIZE;
 
@@ -146,8 +171,262 @@ function cellKey(x, y) {
   return `${x},${y}`;
 }
 
+function parseCellKey(key) {
+  const [sx, sy] = key.split(",");
+  return { x: Number(sx), y: Number(sy) };
+}
+
 function chunkKey(x, y) {
   return `${x},${y}`;
+}
+
+function blockKey(x, y) {
+  return `${x},${y}`;
+}
+
+function parseBlockKey(key) {
+  const [sx, sy] = key.split(",");
+  return { bx: Number(sx), by: Number(sy) };
+}
+
+function pointToBlock(x, y) {
+  return {
+    bx: Math.floor(x / BLOCK_SIZE),
+    by: Math.floor(y / BLOCK_SIZE),
+  };
+}
+
+function forEachCellInBlock(bx, by, callback) {
+  const startX = bx * BLOCK_SIZE;
+  const startY = by * BLOCK_SIZE;
+  for (let x = startX; x < startX + BLOCK_SIZE; x += 1) {
+    for (let y = startY; y < startY + BLOCK_SIZE; y += 1) {
+      callback(x, y);
+    }
+  }
+}
+
+function peekBlockState(bx, by) {
+  return blockStates.get(blockKey(bx, by)) ?? null;
+}
+
+function getBlockState(bx, by) {
+  const key = blockKey(bx, by);
+  let block = blockStates.get(key);
+  if (!block) {
+    const minePositions = new Set();
+    forEachCellInBlock(bx, by, (x, y) => {
+      if (mineAt(x, y)) {
+        minePositions.add(cellKey(x, y));
+      }
+    });
+    const safeCells = BLOCK_SIZE * BLOCK_SIZE - minePositions.size;
+    block = {
+      bx,
+      by,
+      key,
+      mineCount: minePositions.size,
+      minePositions,
+      safeCells,
+      revealedSafe: 0,
+      locked: false,
+      completed: safeCells === 0,
+    };
+    blockStates.set(key, block);
+  }
+  return block;
+}
+
+function refreshBlockGraphics(bx, by) {
+  const startX = bx * BLOCK_SIZE;
+  const startY = by * BLOCK_SIZE;
+  for (let x = startX; x < startX + BLOCK_SIZE; x += 1) {
+    for (let y = startY; y < startY + BLOCK_SIZE; y += 1) {
+      const key = cellKey(x, y);
+      if (cellGraphics.has(key)) {
+        syncCellGraphic(x, y);
+      }
+    }
+  }
+}
+
+function blockSafeCellsLeft(block) {
+  return Math.max(block.safeCells - block.revealedSafe, 0);
+}
+
+function registerRevealedCell(x, y) {
+  const cell = getCellState(x, y);
+  if (cell.mine || cell.blockCounted) {
+    return;
+  }
+  const { bx, by } = pointToBlock(x, y);
+  const block = getBlockState(bx, by);
+  cell.blockCounted = true;
+  block.revealedSafe += 1;
+  if (!block.completed && block.revealedSafe >= block.safeCells) {
+    handleBlockCompletion(block);
+  }
+}
+
+function handleBlockCompletion(block) {
+  if (block.completed) {
+    return;
+  }
+  block.completed = true;
+  block.locked = false;
+  refreshBlockGraphics(block.bx, block.by);
+  state.needsRender = true;
+  scheduleSave();
+
+  const visited = new Set();
+  unlockRegionIfPossible(block.bx, block.by, visited);
+  for (const [dx, dy] of neighborOffsets) {
+    unlockRegionIfPossible(block.bx + dx, block.by + dy, visited);
+  }
+}
+
+function lockBlock(bx, by) {
+  const block = getBlockState(bx, by);
+  if (block.completed || block.locked) {
+    return block;
+  }
+  block.locked = true;
+  refreshBlockGraphics(bx, by);
+  state.needsRender = true;
+  scheduleSave();
+  return block;
+}
+
+function unlockRegionIfPossible(startBx, startBy, visited) {
+  const startKey = blockKey(startBx, startBy);
+  if (visited.has(startKey)) {
+    return false;
+  }
+  const startBlock = peekBlockState(startBx, startBy);
+  if (!startBlock || !startBlock.locked || startBlock.completed) {
+    return false;
+  }
+
+  const region = [];
+  const regionSet = new Set();
+  const stack = [[startBx, startBy]];
+
+  while (stack.length > 0) {
+    const [bx, by] = stack.pop();
+    const key = blockKey(bx, by);
+    if (regionSet.has(key)) {
+      continue;
+    }
+    const block = peekBlockState(bx, by);
+    if (!block || !block.locked || block.completed) {
+      continue;
+    }
+    region.push(block);
+    regionSet.add(key);
+    visited.add(key);
+    for (const [dx, dy] of neighborOffsets) {
+      stack.push([bx + dx, by + dy]);
+    }
+  }
+
+  if (region.length === 0) {
+    return false;
+  }
+
+  let allNeighborsComplete = true;
+  for (const block of region) {
+    for (const [dx, dy] of neighborOffsets) {
+      const nbx = block.bx + dx;
+      const nby = block.by + dy;
+      const neighborKey = blockKey(nbx, nby);
+      if (regionSet.has(neighborKey)) {
+        continue;
+      }
+      const neighborBlock = peekBlockState(nbx, nby);
+      if (!neighborBlock || !neighborBlock.completed) {
+        allNeighborsComplete = false;
+      }
+    }
+  }
+
+  if (!allNeighborsComplete) {
+    return false;
+  }
+
+  for (const block of region) {
+    block.locked = false;
+    refreshBlockGraphics(block.bx, block.by);
+  }
+  state.needsRender = true;
+  scheduleSave();
+  return true;
+}
+
+function isCellLocked(x, y) {
+  const { bx, by } = pointToBlock(x, y);
+  const block = peekBlockState(bx, by);
+  return Boolean(block?.locked && !block.completed);
+}
+
+function autoCompleteBlock(block) {
+  let changed = false;
+  forEachCellInBlock(block.bx, block.by, (x, y) => {
+    const cell = getCellState(x, y);
+    if (!cell.mine && !cell.revealed) {
+      cell.revealed = true;
+      state.revealedSafe += 1;
+      registerRevealedCell(x, y);
+      syncCellGraphic(x, y);
+      changed = true;
+    }
+  });
+
+  if (changed) {
+    updateStatus();
+    state.needsRender = true;
+    scheduleSave();
+  }
+
+  if (!block.completed) {
+    handleBlockCompletion(block);
+  }
+}
+
+function checkBlockAutoComplete(bx, by) {
+  const block = getBlockState(bx, by);
+  if (block.completed || block.locked) {
+    return;
+  }
+
+  let flaggedCorrect = true;
+  let flaggedCount = 0;
+
+  forEachCellInBlock(bx, by, (x, y) => {
+    const key = cellKey(x, y);
+    const cell = getCellState(x, y);
+    const isMine = block.minePositions.has(key);
+    if (cell.flagged) {
+      flaggedCount += 1;
+      if (!isMine) {
+        flaggedCorrect = false;
+      }
+    } else if (isMine) {
+      flaggedCorrect = false;
+    }
+  });
+
+  if (flaggedCorrect && flaggedCount === block.mineCount) {
+    autoCompleteBlock(block);
+  }
+}
+
+function evaluateAllLockedBlocks() {
+  const visited = new Set();
+  for (const block of blockStates.values()) {
+    if (block.locked && !block.completed) {
+      unlockRegionIfPossible(block.bx, block.by, visited);
+    }
+  }
 }
 
 function randomSeedString() {
@@ -181,6 +460,10 @@ function hashPoint(x, y, seedValue) {
 
 function mineAt(x, y) {
   const key = cellKey(x, y);
+  if (forcedSafeCells.has(key)) {
+    mineCache.set(key, false);
+    return false;
+  }
   if (mineCache.has(key)) {
     return mineCache.get(key);
   }
@@ -209,6 +492,7 @@ function getCellState(x, y) {
       adjacent,
       revealed: false,
       flagged: false,
+      blockCounted: false,
     });
   }
   return cellStates.get(key);
@@ -243,7 +527,16 @@ function clearBoardGraphics() {
   chunkLayer.removeChildren();
 }
 
-function resetGame({ newSeed, newDensity, preserveView = false } = {}) {
+function resetGame({ newSeed, newDensity, preserveView = false, skipSaveClear = false } = {}) {
+  if (!skipSaveClear) {
+    clearSavedGame();
+  }
+  cancelPendingSave();
+  hideWarning();
+  hideTargetIndicator();
+  forcedSafeCells.clear();
+  state.startRegionGenerated = false;
+  state.startRegionOrigin = null;
   if (typeof newSeed === "string" && newSeed.trim().length > 0) {
     state.seed = newSeed.trim();
   }
@@ -267,6 +560,7 @@ function resetGame({ newSeed, newDensity, preserveView = false } = {}) {
 
   mineCache.clear();
   cellStates.clear();
+  blockStates.clear();
   clearBoardGraphics();
   state.needsRender = true;
 }
@@ -290,6 +584,262 @@ function updateStatus(message, color) {
     hud.status.textContent = "";
     hud.status.style.color = "#fca5a5";
   }
+}
+
+function showWarning(message, duration = 1600) {
+  const warning = overlays.actionWarning;
+  if (!warning) {
+    return;
+  }
+  warning.textContent = message;
+  warning.classList.add("is-visible");
+  if (warningTimeoutId) {
+    clearTimeout(warningTimeoutId);
+  }
+  warningTimeoutId = window.setTimeout(() => {
+    warning.classList.remove("is-visible");
+    warningTimeoutId = null;
+  }, duration);
+}
+
+function hideWarning() {
+  const warning = overlays.actionWarning;
+  if (!warning) {
+    return;
+  }
+  warning.classList.remove("is-visible");
+  if (warningTimeoutId) {
+    clearTimeout(warningTimeoutId);
+    warningTimeoutId = null;
+  }
+}
+
+function updateTargetIndicator(screenX, screenY) {
+  const indicator = overlays.targetIndicator;
+  if (!indicator) {
+    return;
+  }
+  const world = screenToWorld(screenX, screenY);
+  const cx = Math.floor(world.x / CELL_SIZE);
+  const cy = Math.floor(world.y / CELL_SIZE);
+  const centerWorldX = (cx + 0.5) * CELL_SIZE;
+  const centerWorldY = (cy + 0.5) * CELL_SIZE;
+  const centerScreenX = board.position.x + centerWorldX * state.scale;
+  const centerScreenY = board.position.y + centerWorldY * state.scale;
+  const dx = centerScreenX - screenX;
+  const dy = centerScreenY - screenY;
+  const threshold = CELL_SIZE * state.scale * 0.4;
+  if (Math.hypot(dx, dy) <= threshold) {
+    const { bx, by } = pointToBlock(cx, cy);
+    const block = getBlockState(bx, by);
+    const safeLeft = blockSafeCellsLeft(block);
+    const statusLabel = block.locked && !block.completed
+      ? "Locked"
+      : block.completed
+      ? "Completed"
+      : `${safeLeft} safe left`;
+    indicator.textContent =
+      `Targeting (${cx}, ${cy}) • Block (${bx}, ${by}) • Mines: ${block.mineCount} • ${statusLabel}`;
+    indicator.classList.add("is-visible");
+  } else {
+    indicator.classList.remove("is-visible");
+  }
+}
+
+function hideTargetIndicator() {
+  const indicator = overlays.targetIndicator;
+  if (!indicator) {
+    return;
+  }
+  indicator.classList.remove("is-visible");
+}
+
+function cancelPendingSave() {
+  if (pendingSaveId !== null) {
+    clearTimeout(pendingSaveId);
+    pendingSaveId = null;
+  }
+}
+
+function clearSavedGame() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    lastSavedSnapshot = "";
+  } catch (error) {
+    console.warn("Failed to clear saved game", error);
+  }
+}
+
+function loadSavedGame() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn("Failed to load saved game", error);
+    return null;
+  }
+}
+
+function scheduleSave() {
+  if (state.restoring) {
+    return;
+  }
+  if (pendingSaveId !== null) {
+    clearTimeout(pendingSaveId);
+  }
+  pendingSaveId = window.setTimeout(() => {
+    pendingSaveId = null;
+    saveGame();
+  }, SAVE_DEBOUNCE);
+}
+
+function saveGame() {
+  if (state.restoring) {
+    return;
+  }
+  try {
+    const revealed = [];
+    const flagged = [];
+    for (const cell of cellStates.values()) {
+      if (cell.revealed) {
+        revealed.push([cell.x, cell.y]);
+      } else if (cell.flagged) {
+        flagged.push([cell.x, cell.y]);
+      }
+    }
+
+    const data = {
+      seed: state.seed,
+      mineDensity: state.mineDensity,
+      scale: state.scale,
+      boardPosition: { x: board.position.x, y: board.position.y },
+      revealed,
+      flagged,
+      forcedSafe: Array.from(forcedSafeCells),
+      startRegionGenerated: state.startRegionGenerated,
+      startRegionOrigin: state.startRegionOrigin,
+      revealedSafe: state.revealedSafe,
+      exploded: state.exploded,
+      timestamp: Date.now(),
+      lockedBlocks: Array.from(blockStates.values())
+        .filter((block) => block.locked && !block.completed)
+        .map((block) => [block.bx, block.by]),
+    };
+
+    const snapshot = JSON.stringify(data);
+    if (snapshot === lastSavedSnapshot) {
+      return;
+    }
+    localStorage.setItem(STORAGE_KEY, snapshot);
+    lastSavedSnapshot = snapshot;
+  } catch (error) {
+    console.warn("Failed to save game", error);
+  }
+}
+
+function applySavedGame(data) {
+  if (!data) {
+    return;
+  }
+
+  state.restoring = true;
+  forcedSafeCells.clear();
+  if (Array.isArray(data.forcedSafe)) {
+    for (const key of data.forcedSafe) {
+      if (typeof key === "string") {
+        forcedSafeCells.add(key);
+      }
+    }
+  }
+
+  mineCache.clear();
+  cellStates.clear();
+  blockStates.clear();
+  clearBoardGraphics();
+
+  if (typeof data.scale === "number" && Number.isFinite(data.scale)) {
+    state.scale = clamp(data.scale, MIN_SCALE, MAX_SCALE);
+    board.scale.set(state.scale);
+  }
+  if (
+    data.boardPosition &&
+    typeof data.boardPosition.x === "number" &&
+    typeof data.boardPosition.y === "number"
+  ) {
+    board.position.set(data.boardPosition.x, data.boardPosition.y);
+  }
+
+  state.startRegionGenerated = Boolean(data.startRegionGenerated) || forcedSafeCells.size > 0;
+  if (
+    data.startRegionOrigin &&
+    typeof data.startRegionOrigin.x === "number" &&
+    typeof data.startRegionOrigin.y === "number"
+  ) {
+    state.startRegionOrigin = {
+      x: Math.trunc(data.startRegionOrigin.x),
+      y: Math.trunc(data.startRegionOrigin.y),
+    };
+  } else {
+    state.startRegionOrigin = null;
+  }
+  state.revealedSafe = 0;
+  state.exploded = false;
+
+  const revealedList = Array.isArray(data.revealed) ? data.revealed : [];
+  for (const entry of revealedList) {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      continue;
+    }
+    const [x, y] = entry;
+    const cell = getCellState(x, y);
+    cell.revealed = true;
+    if (!cell.mine) {
+      state.revealedSafe += 1;
+    }
+    registerRevealedCell(x, y);
+    syncCellGraphic(x, y);
+  }
+
+  const flaggedList = Array.isArray(data.flagged) ? data.flagged : [];
+  for (const entry of flaggedList) {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      continue;
+    }
+    const [x, y] = entry;
+    const cell = getCellState(x, y);
+    if (!cell.revealed) {
+      cell.flagged = true;
+    }
+    syncCellGraphic(x, y);
+  }
+
+  if (typeof data.revealedSafe === "number" && Number.isFinite(data.revealedSafe)) {
+    state.revealedSafe = data.revealedSafe;
+  }
+
+  const lockedList = Array.isArray(data.lockedBlocks) ? data.lockedBlocks : [];
+  for (const entry of lockedList) {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      continue;
+    }
+    const [bx, by] = entry;
+    const block = getBlockState(bx, by);
+    if (!block.completed) {
+      block.locked = true;
+      refreshBlockGraphics(bx, by);
+    }
+  }
+
+  evaluateAllLockedBlocks();
+
+  updateStatus();
+  state.needsRender = true;
+  state.restoring = false;
+  lastSavedSnapshot = JSON.stringify(data);
+  scheduleSave();
 }
 
 function createCellGraphic(x, y) {
@@ -321,11 +871,19 @@ function syncCellGraphic(x, y) {
   const flagged = stateForCell?.flagged ?? false;
   const mine = stateForCell?.mine ?? false;
   const adjacent = stateForCell?.adjacent ?? 0;
+  const locked = isCellLocked(x, y);
 
   background.clear();
-  background.lineStyle(1, 0x000000, revealed ? 0.25 : 0.45);
-  const fillColor = revealed ? (mine ? EXPLODED_COLOR : REVEALED_COLOR) : BACKGROUND_COLOR;
-  background.beginFill(fillColor, revealed ? 0.95 : 0.92);
+  background.lineStyle(1, locked ? 0xfca5a5 : 0x000000, revealed ? 0.25 : locked ? 0.6 : 0.45);
+  const fillColor = revealed
+    ? mine
+      ? EXPLODED_COLOR
+      : REVEALED_COLOR
+    : locked
+    ? 0x7f1d1d
+    : BACKGROUND_COLOR;
+  const fillAlpha = revealed ? 0.95 : locked ? 0.9 : 0.92;
+  background.beginFill(fillColor, fillAlpha);
   background.drawRoundedRect(0, 0, CELL_SIZE, CELL_SIZE, Math.min(10, CELL_SIZE / 4));
   background.endFill();
 
@@ -342,6 +900,9 @@ function syncCellGraphic(x, y) {
   } else if (flagged) {
     label.text = "⚑";
     label.style = styles.flag;
+  } else if (locked) {
+    label.text = "🔒";
+    label.style = styles.lock;
   } else {
     label.text = "";
   }
@@ -464,8 +1025,98 @@ function refreshVisibleCells() {
   }
 }
 
+function ensureStartingRegion(x, y) {
+  if (state.startRegionGenerated) {
+    return;
+  }
+
+  state.startRegionGenerated = true;
+  state.startRegionOrigin = { x, y };
+
+  const region = new Set();
+  const queue = [[x, y]];
+  const visited = new Set();
+  const impactedBlocks = new Set();
+
+  while (region.size < START_REGION_SIZE && queue.length > 0) {
+    const idx = Math.floor(Math.random() * queue.length);
+    const [cx, cy] = queue.splice(idx, 1)[0];
+    const key = cellKey(cx, cy);
+    if (visited.has(key)) {
+      continue;
+    }
+    visited.add(key);
+    region.add(key);
+    for (const [dx, dy] of neighborOffsets) {
+      queue.push([cx + dx, cy + dy]);
+    }
+  }
+
+  if (region.size < START_REGION_SIZE) {
+    const regionArray = Array.from(region).map((key) => parseCellKey(key));
+    let attempts = 0;
+    while (region.size < START_REGION_SIZE && attempts < START_REGION_SIZE * 8) {
+      const base = regionArray[Math.floor(Math.random() * regionArray.length)] ?? { x, y };
+      const [dx, dy] = neighborOffsets[Math.floor(Math.random() * neighborOffsets.length)];
+      const nx = base.x + dx;
+      const ny = base.y + dy;
+      const key = cellKey(nx, ny);
+      if (!region.has(key)) {
+        region.add(key);
+        regionArray.push({ x: nx, y: ny });
+      }
+      attempts += 1;
+    }
+  }
+
+  const impacted = new Set();
+  for (const key of region) {
+    forcedSafeCells.add(key);
+    mineCache.set(key, false);
+    impacted.add(key);
+    const { x: cx, y: cy } = parseCellKey(key);
+    const { bx, by } = pointToBlock(cx, cy);
+    impactedBlocks.add(blockKey(bx, by));
+    const block = peekBlockState(bx, by);
+    if (block && block.minePositions.delete(key)) {
+      block.mineCount = Math.max(0, block.mineCount - 1);
+      block.safeCells += 1;
+      if (block.safeCells > 0 && block.completed) {
+        block.completed = false;
+      }
+    }
+    for (const [dx, dy] of neighborOffsets) {
+      impacted.add(cellKey(cx + dx, cy + dy));
+    }
+  }
+
+  for (const key of impacted) {
+    cellStates.delete(key);
+    if (cellGraphics.has(key)) {
+      const { x: gx, y: gy } = parseCellKey(key);
+      const cell = getCellState(gx, gy);
+      if (cell) {
+        syncCellGraphic(gx, gy);
+      }
+    }
+  }
+
+  for (const bKey of impactedBlocks) {
+    const { bx, by } = parseBlockKey(bKey);
+    refreshBlockGraphics(bx, by);
+  }
+  state.needsRender = true;
+}
+
 function revealCell(x, y) {
   if (state.exploded) {
+    return false;
+  }
+  ensureStartingRegion(x, y);
+  const { bx, by } = pointToBlock(x, y);
+  const block = getBlockState(bx, by);
+  if (block.locked && !block.completed) {
+    showWarning("This block is locked. Complete surrounding blocks to unlock it.");
     return false;
   }
   const start = getCellState(x, y);
@@ -483,12 +1134,9 @@ function revealCell(x, y) {
   let anyRevealed = false;
 
   if (start.mine) {
-    start.revealed = true;
-    syncCellGraphic(x, y);
-    state.exploded = true;
-    updateStatus();
-    state.needsRender = true;
-    return true;
+    lockBlock(bx, by);
+    showWarning("Block locked! Solve the surrounding blocks to unlock it.");
+    return false;
   }
 
   const stack = [[x, y]];
@@ -503,13 +1151,14 @@ function revealCell(x, y) {
     visited.add(key);
 
     const cell = getCellState(cx, cy);
-    if (cell.revealed || cell.flagged || cell.mine) {
+    if (cell.revealed || cell.flagged || cell.mine || isCellLocked(cx, cy)) {
       continue;
     }
 
     cell.revealed = true;
     state.revealedSafe += 1;
     syncCellGraphic(cx, cy);
+    registerRevealedCell(cx, cy);
     anyRevealed = true;
 
     if (cell.adjacent === 0) {
@@ -517,7 +1166,7 @@ function revealCell(x, y) {
         const nx = cx + dx;
         const ny = cy + dy;
         const neighbor = getCellState(nx, ny);
-        if (!neighbor.revealed && !neighbor.flagged && !neighbor.mine) {
+        if (!neighbor.revealed && !neighbor.flagged && !neighbor.mine && !isCellLocked(nx, ny)) {
           stack.push([nx, ny]);
         }
       }
@@ -527,6 +1176,7 @@ function revealCell(x, y) {
   updateStatus();
   if (anyRevealed) {
     state.needsRender = true;
+    scheduleSave();
   }
   return anyRevealed;
 }
@@ -539,9 +1189,16 @@ function toggleFlag(x, y) {
   if (cell.revealed) {
     return false;
   }
+  if (isCellLocked(x, y)) {
+    showWarning("This block is locked. Complete surrounding blocks to unlock it.");
+    return false;
+  }
+  const { bx, by } = pointToBlock(x, y);
   cell.flagged = !cell.flagged;
   syncCellGraphic(x, y);
+  checkBlockAutoComplete(bx, by);
   state.needsRender = true;
+  scheduleSave();
   return true;
 }
 
@@ -555,13 +1212,40 @@ function revealNeighborsOfNumber(x, y) {
     return false;
   }
 
+  let flaggedNeighbors = 0;
+  let hiddenNeighbors = 0;
+  for (const [dx, dy] of neighborOffsets) {
+    const neighbor = getCellState(x + dx, y + dy);
+    if (neighbor.flagged) {
+      flaggedNeighbors += 1;
+    }
+    if (!neighbor.revealed) {
+      hiddenNeighbors += 1;
+    }
+  }
+
+  if (hiddenNeighbors > 0 && flaggedNeighbors < center.adjacent) {
+    const remaining = center.adjacent - flaggedNeighbors;
+    showWarning(
+      remaining === 1
+        ? "Place 1 more flag before chording this number."
+        : `Place ${remaining} more flags before chording this number.`
+    );
+    return false;
+  }
+
+  if (flaggedNeighbors > center.adjacent) {
+    showWarning("Too many flags are marked around this number.");
+    return false;
+  }
+
   let changed = false;
 
   for (const [dx, dy] of neighborOffsets) {
     const nx = x + dx;
     const ny = y + dy;
     const neighbor = getCellState(nx, ny);
-    if (neighbor.flagged || neighbor.revealed) {
+    if (neighbor.flagged || neighbor.revealed || isCellLocked(nx, ny)) {
       continue;
     }
     if (revealCell(nx, ny)) {
@@ -588,12 +1272,14 @@ function handleWheel(event) {
     offsetY - worldBefore.y * state.scale
   );
   state.needsRender = true;
+  scheduleSave();
 }
 
 function onPointerDown(event) {
   if (state.pointer.pointerId !== null) {
     return;
   }
+  updateTargetIndicator(event.global.x, event.global.y);
   state.pointer.pointerId = event.pointerId;
   state.pointer.button = event.button;
   state.pointer.startX = event.global.x;
@@ -604,6 +1290,7 @@ function onPointerDown(event) {
 }
 
 function onPointerMove(event) {
+  updateTargetIndicator(event.global.x, event.global.y);
   if (state.pointer.pointerId !== event.pointerId) {
     return;
   }
@@ -628,6 +1315,7 @@ function onPointerMove(event) {
     board.position.x += dx;
     board.position.y += dy;
     state.needsRender = true;
+    scheduleSave();
   }
 
   state.pointer.lastX = global.x;
@@ -647,6 +1335,8 @@ function finishPointer(event) {
   state.pointer.pointerId = null;
   state.pointer.dragging = false;
 
+  updateTargetIndicator(globalX, globalY);
+
   if (button === 0 && !wasDragging) {
     const { cx, cy } = screenToCell(globalX, globalY);
     revealCell(cx, cy);
@@ -660,6 +1350,7 @@ interactionLayer.on("pointerdown", onPointerDown);
 interactionLayer.on("pointermove", onPointerMove);
 interactionLayer.on("pointerup", finishPointer);
 interactionLayer.on("pointerupoutside", finishPointer);
+interactionLayer.on("pointerout", hideTargetIndicator);
 interactionLayer.on("rightdown", (event) => {
   event.preventDefault();
 });
@@ -721,4 +1412,26 @@ window.addEventListener("keydown", (event) => {
   }
 });
 
-resetGame({ preserveView: false });
+const savedGame = loadSavedGame();
+if (savedGame) {
+  const seedToUse =
+    typeof savedGame.seed === "string" && savedGame.seed.trim().length > 0
+      ? savedGame.seed.trim()
+      : state.seed;
+  const densityToUse =
+    typeof savedGame.mineDensity === "number" && Number.isFinite(savedGame.mineDensity)
+      ? savedGame.mineDensity
+      : state.mineDensity;
+
+  state.restoring = true;
+  resetGame({
+    newSeed: seedToUse,
+    newDensity: densityToUse,
+    preserveView: true,
+    skipSaveClear: true,
+  });
+  state.restoring = false;
+  applySavedGame(savedGame);
+} else {
+  resetGame({ preserveView: false });
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -134,3 +134,51 @@ kbd {
   border: 1px solid rgba(148, 163, 184, 0.4);
   font-size: 0.75rem;
 }
+
+.target-indicator {
+  position: fixed;
+  left: 1.25rem;
+  bottom: 1.25rem;
+  min-width: 220px;
+  padding: 0.4rem 0.7rem;
+  border-radius: 0.55rem;
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+  letter-spacing: 0.01em;
+  z-index: 12;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.target-indicator.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.action-warning {
+  position: fixed;
+  left: 50%;
+  bottom: 2.5rem;
+  transform: translate(-50%, 20px);
+  padding: 0.55rem 1.1rem;
+  border-radius: 0.65rem;
+  background: rgba(248, 113, 113, 0.9);
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 16px 36px rgba(248, 113, 113, 0.3);
+  z-index: 15;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.action-warning.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
## Summary
- add block-level bookkeeping that locks 30×30 regions when mines are clicked and unlocks them once surrounding blocks finish
- surface per-block mine counts and status in the targeting HUD while auto-completing blocks when the flag layout matches
- persist locked block state and thread block awareness through starting-region seeding, reveal, and flagging logic

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e10fcb0dbc832e85787f5b9a5a37be