### PR TITLE
Improve persistence, flag warnings, and mobile support

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,7 +27,7 @@
         </label>
       </div>
       <p class="hud__hint">
-        Left click to reveal, right click to flag. Drag to pan, scroll to zoom. Press <kbd>R</kbd> to reset the current seed.
+        Left click or tap to reveal. Right click or long-press to flag. Drag to pan, scroll to zoom. Press <kbd>R</kbd> to reset the current seed.
       </p>
       <p class="hud__status" id="status"></p>
     </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -22,6 +22,7 @@ canvas {
   height: 100%;
   display: block;
   z-index: 0;
+  touch-action: none;
 }
 
 .hud {
@@ -57,6 +58,7 @@ canvas {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .hud__controls label {
@@ -92,6 +94,7 @@ canvas {
   color: #0f172a;
   background: linear-gradient(135deg, #38bdf8, #818cf8);
   transition: transform 0.12s ease, filter 0.12s ease;
+  min-height: 2.25rem;
 }
 
 .hud button:active {
@@ -181,4 +184,69 @@ kbd {
 .action-warning.is-visible {
   opacity: 1;
   transform: translate(-50%, 0);
+}
+
+@media (max-width: 900px) {
+  .hud {
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(420px, calc(100vw - 2rem));
+    max-width: none;
+  }
+
+  .hud__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .hud__controls {
+    gap: 0.6rem;
+  }
+
+  .hud button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .hud {
+    bottom: 1rem;
+    top: auto;
+    padding: 0.85rem 1rem;
+    gap: 0.6rem;
+  }
+
+  .hud__hint {
+    font-size: 0.75rem;
+  }
+
+  .hud__status {
+    font-size: 0.8rem;
+  }
+
+  .target-indicator {
+    left: 50%;
+    top: 1rem;
+    bottom: auto;
+    width: calc(100vw - 2rem);
+    min-width: auto;
+    text-align: center;
+    transform: translate(-50%, 6px);
+    font-size: 0.8rem;
+    padding: 0.5rem 0.7rem;
+  }
+
+  .target-indicator.is-visible {
+    transform: translate(-50%, 0);
+  }
+
+  .action-warning {
+    bottom: 1.25rem;
+    width: calc(100vw - 2.5rem);
+    max-width: 28rem;
+    text-align: center;
+    font-size: 0.85rem;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure saved-game snapshots restore board state before any reset clears it and fall back cleanly on corrupted data
- warn immediately when toggling a flag causes neighboring clues to become over-flagged
- add long-press flagging and responsive HUD/overlay styles for touch-friendly mobile play

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e123177140832ea0381d3bbcf05e89