### PR TITLE
Add HUD toggle, pinch zoom, and safer reset handling

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,29 +7,41 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <div class="hud" id="hud">
-      <div class="hud__header">
-        <h1>Infinite Minesweeper</h1>
-        <button id="reset">Reset</button>
+    <div class="hud-shell" id="hud-shell">
+      <div class="hud" id="hud">
+        <div class="hud__header">
+          <h1>Infinite Minesweeper</h1>
+          <button id="reset">Reset</button>
+        </div>
+        <div class="hud__controls">
+          <label>
+            Seed
+            <input id="seed" type="text" autocomplete="off" spellcheck="false" />
+          </label>
+          <button id="random-seed">Random</button>
+        </div>
+        <div class="hud__controls">
+          <label class="slider">
+            Mine density
+            <input id="density" type="range" min="0.05" max="0.35" step="0.01" value="0.18" />
+            <span id="density-value">18%</span>
+          </label>
+        </div>
+        <p class="hud__hint">
+          Left click or tap to reveal. Right click or long-press to flag. Drag to pan, scroll or pinch to zoom. Press <kbd>R</kbd> to reset the current seed.
+        </p>
+        <p class="hud__status" id="status"></p>
       </div>
-      <div class="hud__controls">
-        <label>
-          Seed
-          <input id="seed" type="text" autocomplete="off" spellcheck="false" />
-        </label>
-        <button id="random-seed">Random</button>
-      </div>
-      <div class="hud__controls">
-        <label class="slider">
-          Mine density
-          <input id="density" type="range" min="0.05" max="0.35" step="0.01" value="0.18" />
-          <span id="density-value">18%</span>
-        </label>
-      </div>
-      <p class="hud__hint">
-        Left click or tap to reveal. Right click or long-press to flag. Drag to pan, scroll to zoom. Press <kbd>R</kbd> to reset the current seed.
-      </p>
-      <p class="hud__status" id="status"></p>
+      <button
+        class="hud-toggle"
+        id="hud-toggle"
+        type="button"
+        aria-controls="hud"
+        aria-expanded="true"
+      >
+        <span class="hud-toggle__icon" aria-hidden="true">➤</span>
+        <span class="visually-hidden">Hide controls</span>
+      </button>
     </div>
     <div class="target-indicator" id="target-indicator" aria-live="polite"></div>
     <div class="action-warning" id="action-warning" aria-live="assertive"></div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -25,10 +25,17 @@ canvas {
   touch-action: none;
 }
 
-.hud {
+.hud-shell {
   position: fixed;
   top: 1.25rem;
   left: 1.25rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  z-index: 10;
+}
+
+.hud {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -37,8 +44,66 @@ canvas {
   background: rgba(15, 23, 42, 0.72);
   backdrop-filter: blur(18px);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
-  max-width: min(360px, calc(100vw - 2.5rem));
-  z-index: 10;
+  width: min(360px, calc(100vw - 2.5rem));
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.hud-shell.is-collapsed .hud {
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+}
+
+.hud-toggle {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.72);
+  color: #cbd5f5;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
+  z-index: 11;
+}
+
+.hud-toggle:hover {
+  background: rgba(30, 41, 59, 0.85);
+  color: #f8fafc;
+}
+
+.hud-toggle:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.9);
+  outline-offset: 3px;
+}
+
+.hud-toggle:active {
+  transform: translateY(1px) scale(0.97);
+}
+
+.hud-toggle__icon {
+  font-size: 1.1rem;
+  transition: transform 0.18s ease;
+}
+
+.hud-shell:not(.is-collapsed) .hud-toggle__icon {
+  transform: rotate(180deg);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .hud h1 {
@@ -187,12 +252,21 @@ kbd {
 }
 
 @media (max-width: 900px) {
-  .hud {
+  .hud-shell {
     top: 1rem;
     left: 50%;
     transform: translateX(-50%);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+  }
+
+  .hud {
     width: min(420px, calc(100vw - 2rem));
-    max-width: none;
+  }
+
+  .hud-toggle {
+    align-self: center;
   }
 
   .hud__header {
@@ -211,9 +285,12 @@ kbd {
 }
 
 @media (max-width: 640px) {
-  .hud {
+  .hud-shell {
     bottom: 1rem;
     top: auto;
+  }
+
+  .hud {
     padding: 0.85rem 1rem;
     gap: 0.6rem;
   }


### PR DESCRIPTION
## Summary
- shrink tile rendering to show more of the board at once while updating text styles
- add a collapsible HUD with a toggle button and persist the collapsed state in saves
- enable touch pinch-to-zoom support and require confirmation for keyboard resets

## Testing
- node --check web/main.js

------
https://chatgpt.com/codex/tasks/task_e_68e12a139ef8832ea73439d951c819e0