### PR TITLE
Add light theme and sharper board visuals

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -1,50 +1,58 @@
 import * as PIXI from "https://cdn.jsdelivr.net/npm/pixi.js@7.3.3/dist/pixi.mjs";
 
+const DEVICE_RESOLUTION = Math.min(window.devicePixelRatio || 1, 3);
+const TEXT_RESOLUTION = Math.max(DEVICE_RESOLUTION, 2);
+PIXI.Text.defaultResolution = TEXT_RESOLUTION;
+
 const CELL_SIZE = 24;
 const CHUNK_SIZE = 8;
-const BLOCK_SIZE = 30;
+const BLOCK_SIZE = 20;
 const MIN_SCALE = 0.35;
 const MAX_SCALE = 3.2;
 const GROUPING_THRESHOLD = 0.65;
-const BACKGROUND_COLOR = 0x0f172a;
-const REVEALED_COLOR = 0x1e293b;
-const EXPLODED_COLOR = 0xb91c1c;
+const BACKGROUND_COLOR = 0xe2e8f0;
+const REVEALED_COLOR = 0xf8fafc;
+const EXPLODED_COLOR = 0xfca5a5;
 
 const NUMBER_COLORS = {
-  1: "#38bdf8",
-  2: "#4ade80",
-  3: "#f87171",
-  4: "#a855f7",
-  5: "#f97316",
-  6: "#0ea5e9",
-  7: "#fbbf24",
-  8: "#cbd5f5",
+  1: "#1d4ed8",
+  2: "#15803d",
+  3: "#dc2626",
+  4: "#7c3aed",
+  5: "#b45309",
+  6: "#0f766e",
+  7: "#be123c",
+  8: "#334155",
 };
 
 const styles = {
   flag: new PIXI.TextStyle({
-    fill: "#fb7185",
+    fill: "#dc2626",
     fontSize: 18,
     fontWeight: "700",
     fontFamily: "Inter, 'Segoe UI', sans-serif",
+    resolution: TEXT_RESOLUTION,
   }),
   mine: new PIXI.TextStyle({
-    fill: "#facc15",
+    fill: "#b91c1c",
     fontSize: 20,
     fontWeight: "700",
     fontFamily: "Inter, 'Segoe UI', sans-serif",
+    resolution: TEXT_RESOLUTION,
   }),
   empty: new PIXI.TextStyle({
-    fill: "#f8fafc",
+    fill: "#475569",
     fontSize: 15,
     fontWeight: "600",
     fontFamily: "Inter, 'Segoe UI', sans-serif",
+    resolution: TEXT_RESOLUTION,
   }),
   lock: new PIXI.TextStyle({
-    fill: "#facc15",
+    fill: "#b45309",
     fontSize: 18,
     fontWeight: "600",
     fontFamily: "Inter, 'Segoe UI', sans-serif",
+    resolution: TEXT_RESOLUTION,
   }),
 };
 
@@ -54,10 +62,11 @@ function styleForNumber(value) {
     numberStyles.set(
       value,
       new PIXI.TextStyle({
-        fill: NUMBER_COLORS[value] ?? "#e2e8f0",
+        fill: NUMBER_COLORS[value] ?? "#1f2937",
         fontSize: 18,
         fontWeight: "700",
         fontFamily: "Inter, 'Segoe UI', sans-serif",
+        resolution: TEXT_RESOLUTION,
       })
     );
   }
@@ -79,6 +88,8 @@ const app = new PIXI.Application({
   backgroundAlpha: 0,
   antialias: true,
   resizeTo: window,
+  autoDensity: true,
+  resolution: DEVICE_RESOLUTION,
 });
 
 document.body.appendChild(app.view);
@@ -180,9 +191,9 @@ const blockStates = new Map();
 const CHUNK_WORLD_SIZE = CHUNK_SIZE * CELL_SIZE;
 
 const chunkStyles = {
-  untouched: { fill: 0x0f172a, alpha: 0.22, border: 0x1e293b, borderAlpha: 0.28 },
-  interesting: { fill: 0x38bdf8, alpha: 0.24, border: 0x7dd3fc, borderAlpha: 0.45 },
-  danger: { fill: EXPLODED_COLOR, alpha: 0.35, border: 0xf87171, borderAlpha: 0.6 },
+  untouched: { fill: 0xffffff, alpha: 0.35, border: 0x94a3b8, borderAlpha: 0.45 },
+  interesting: { fill: 0xbae6fd, alpha: 0.4, border: 0x38bdf8, borderAlpha: 0.6 },
+  danger: { fill: EXPLODED_COLOR, alpha: 0.45, border: 0xf87171, borderAlpha: 0.7 },
 };
 
 function setHudCollapsed(collapsed) {
@@ -634,13 +645,13 @@ function updateStatus(message, color) {
 
   if (state.exploded) {
     hud.status.textContent = "Boom! That was a mine. Reset or try a new seed.";
-    hud.status.style.color = "#fca5a5";
+    hud.status.style.color = "#b91c1c";
   } else if (state.revealedSafe > 0) {
     hud.status.textContent = `Safe tiles revealed: ${state.revealedSafe}`;
-    hud.status.style.color = "#bbf7d0";
+    hud.status.style.color = "#166534";
   } else {
     hud.status.textContent = "";
-    hud.status.style.color = "#fca5a5";
+    hud.status.style.color = "#b91c1c";
   }
 }
 
@@ -917,6 +928,8 @@ function createCellGraphic(x, y) {
   const label = new PIXI.Text("", styles.empty);
   label.anchor.set(0.5);
   label.position.set(CELL_SIZE / 2, CELL_SIZE / 2);
+  label.resolution = TEXT_RESOLUTION;
+  label.roundPixels = true;
   container.addChild(label);
 
   cellLayer.addChild(container);
@@ -939,15 +952,16 @@ function syncCellGraphic(x, y) {
   const locked = isCellLocked(x, y);
 
   background.clear();
-  background.lineStyle(1, locked ? 0xfca5a5 : 0x000000, revealed ? 0.25 : locked ? 0.6 : 0.45);
+  const borderColor = locked ? 0xf97316 : 0x94a3b8;
+  background.lineStyle(1, borderColor, revealed ? 0.35 : locked ? 0.8 : 0.55);
   const fillColor = revealed
     ? mine
       ? EXPLODED_COLOR
       : REVEALED_COLOR
     : locked
-    ? 0x7f1d1d
+    ? 0xfef3c7
     : BACKGROUND_COLOR;
-  const fillAlpha = revealed ? 0.95 : locked ? 0.9 : 0.92;
+  const fillAlpha = revealed ? 1 : locked ? 1 : 0.95;
   background.beginFill(fillColor, fillAlpha);
   background.drawRoundedRect(0, 0, CELL_SIZE, CELL_SIZE, Math.min(10, CELL_SIZE / 4));
   background.endFill();

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: dark;
+  color-scheme: light;
   font-family: "Inter", "Segoe UI", sans-serif;
 }
 
@@ -11,8 +11,8 @@ body {
 }
 
 body {
-  background: radial-gradient(circle at top, #1b263b 0%, #0d1117 60%, #05070a 100%);
-  color: #f1f5f9;
+  background: radial-gradient(circle at top, #f8fafc 0%, #e2e8f0 55%, #cbd5f5 100%);
+  color: #0f172a;
 }
 
 canvas {
@@ -41,17 +41,40 @@ canvas {
   gap: 0.75rem;
   padding: 1rem 1.25rem;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.72);
+  background: rgba(255, 255, 255, 0.88);
   backdrop-filter: blur(18px);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 18px 40px rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   width: min(360px, calc(100vw - 2.5rem));
-  transition: opacity 0.18s ease, transform 0.18s ease;
+  max-width: min(360px, calc(100vw - 2.5rem));
+  overflow: hidden;
+  transition: opacity 0.18s ease, transform 0.18s ease, max-width 0.18s ease,
+    padding 0.18s ease, margin 0.18s ease, box-shadow 0.18s ease,
+    border-color 0.18s ease, border-width 0.18s ease;
+}
+
+.hud-shell.is-collapsed {
+  pointer-events: none;
+  gap: 0;
 }
 
 .hud-shell.is-collapsed .hud {
   opacity: 0;
   transform: translateY(-10px);
   pointer-events: none;
+  max-width: 0;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  box-shadow: none;
+}
+
+.hud-shell.is-collapsed .hud-toggle {
+  pointer-events: auto;
+  position: relative;
+  left: 0;
+  top: 0;
 }
 
 .hud-toggle {
@@ -63,21 +86,22 @@ canvas {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(15, 23, 42, 0.72);
-  color: #cbd5f5;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+  background: rgba(255, 255, 255, 0.88);
+  color: #334155;
+  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.3);
   cursor: pointer;
   transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease;
   z-index: 11;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .hud-toggle:hover {
-  background: rgba(30, 41, 59, 0.85);
-  color: #f8fafc;
+  background: rgba(241, 245, 249, 0.95);
+  color: #0f172a;
 }
 
 .hud-toggle:focus-visible {
-  outline: 2px solid rgba(96, 165, 250, 0.9);
+  outline: 2px solid rgba(59, 130, 246, 0.65);
   outline-offset: 3px;
 }
 
@@ -110,6 +134,7 @@ canvas {
   font-size: 1.25rem;
   margin: 0;
   font-weight: 600;
+  color: #0f172a;
 }
 
 .hud__header {
@@ -131,21 +156,21 @@ canvas {
   flex-direction: column;
   font-size: 0.85rem;
   gap: 0.35rem;
-  color: #cbd5f5;
+  color: #334155;
 }
 
 .hud input[type="text"] {
   appearance: none;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.6);
   border-radius: 0.5rem;
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(255, 255, 255, 0.9);
   padding: 0.4rem 0.6rem;
-  color: inherit;
+  color: #0f172a;
   font-size: 0.95rem;
 }
 
 .hud input[type="text"]:focus {
-  outline: 2px solid rgba(96, 165, 250, 0.65);
+  outline: 2px solid rgba(59, 130, 246, 0.6);
   outline-offset: 1px;
 }
 
@@ -156,10 +181,11 @@ canvas {
   font-weight: 600;
   font-size: 0.85rem;
   cursor: pointer;
-  color: #0f172a;
-  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #f8fafc;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
   transition: transform 0.12s ease, filter 0.12s ease;
   min-height: 2.25rem;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
 }
 
 .hud button:active {
@@ -172,7 +198,7 @@ canvas {
 
 .slider input[type="range"] {
   width: 100%;
-  accent-color: #38bdf8;
+  accent-color: #2563eb;
 }
 
 #density-value {
@@ -184,14 +210,14 @@ canvas {
   margin: 0;
   font-size: 0.8rem;
   line-height: 1.45;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(15, 23, 42, 0.7);
 }
 
 .hud__status {
   min-height: 1.2rem;
   margin: 0;
   font-size: 0.9rem;
-  color: #fca5a5;
+  color: #b91c1c;
 }
 
 kbd {
@@ -201,6 +227,7 @@ kbd {
   background: rgba(148, 163, 184, 0.25);
   border: 1px solid rgba(148, 163, 184, 0.4);
   font-size: 0.75rem;
+  color: #0f172a;
 }
 
 .target-indicator {
@@ -210,16 +237,17 @@ kbd {
   min-width: 220px;
   padding: 0.4rem 0.7rem;
   border-radius: 0.55rem;
-  background: rgba(15, 23, 42, 0.72);
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 32px rgba(148, 163, 184, 0.25);
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.85);
+  color: #1f2937;
   letter-spacing: 0.01em;
   z-index: 12;
   pointer-events: none;
   opacity: 0;
   transform: translateY(6px);
   transition: opacity 0.18s ease, transform 0.18s ease;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .target-indicator.is-visible {
@@ -234,16 +262,17 @@ kbd {
   transform: translate(-50%, 20px);
   padding: 0.55rem 1.1rem;
   border-radius: 0.65rem;
-  background: rgba(248, 113, 113, 0.9);
-  color: #0f172a;
+  background: rgba(248, 113, 113, 0.92);
+  color: #7f1d1d;
   font-weight: 600;
   font-size: 0.9rem;
   letter-spacing: 0.01em;
-  box-shadow: 0 16px 36px rgba(248, 113, 113, 0.3);
+  box-shadow: 0 16px 36px rgba(248, 113, 113, 0.25);
   z-index: 15;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.2s ease, transform 0.2s ease;
+  border: 1px solid rgba(248, 113, 113, 0.4);
 }
 
 .action-warning.is-visible {


### PR DESCRIPTION
## Summary
- restyle the interface with a new light theme and lighter overlays
- update cell rendering colors, shrink explosive block radius, and keep HUD clicks unobstructed when hidden
- improve text rendering resolution so digits stay sharp while zooming
- keep the HUD toggle parked by the edge when the controls are collapsed on any screen size

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1309e7cb8832ea8b02a7d8162f90a