### PR TITLE
Fix long-press flagging reliability and hide touch slider on desktop

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,7 +27,7 @@
             <span id="density-value">18%</span>
           </label>
         </div>
-        <div class="hud__controls">
+        <div class="hud__controls" data-touch-only>
           <label class="slider">
             Flag hold time
             <input id="flag-hold" type="range" min="150" max="900" step="25" value="450" />


### PR DESCRIPTION
## Summary
- hide the flag hold slider on devices without coarse pointers while keeping it visible on touch hardware
- improve long-press flagging by resolving pointer types more reliably and reusing the updated hold duration
- guard the flag hold slider events against invalid input values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5239c49cc832e8bd0e60cd3697583